### PR TITLE
implemented function for switching device to slow clock

### DIFF
--- a/sam4s/mcu.c
+++ b/sam4s/mcu.c
@@ -306,53 +306,31 @@ mcu_reset (void)
 }
 
 
-/* Place this function in SRAM to avoid problem when switching from
-   PLLCK to SLCK.  See errata 39.4.4.2.  */
 void
-mcu_power_mode_low (void)
-    __attribute__ ((section(".ramtext")));
-
-
-void
-mcu_power_mode_low (void)
+mcu_select_slowclock (void)
 {
-    /* Deactivating the brownout detector saves 20 uA; this requires
-       programming of the GPNVM bits.  */
-       
-    /* Disabling the UDP saves ??? uA.  Connecting the USB port pins
-       to ground also saves about 100 uA.  */
-    mcu_udp_disable ();
-
-#if 0
-    /* TODO.  */
-
     /* Switch main clock (MCK) from PLLCLK to SLCK.  Note the prescale
        (PRES) and clock source (CSS) fields cannot be changed at the
        same time.  We first switch from the PLLCLK to SLCK then set
        the prescaler to divide by 64. */
-    PMC->PMC_MCKR = (PMC->PMC_MCKR & AT91C_PMC_PRES)
-        | AT91C_PMC_CSS_SLOW_CLK;
+    PMC->PMC_MCKR = (PMC->PMC_MCKR & PMC_MCKR_PRES_Msk)
+        | PMC_MCKR_CSS_SLOW_CLK;
 
-    while (!(PMC->PMC_SR & AT91C_PMC_MCKRDY))
+    while (!(PMC->PMC_SR & PMC_SR_MCKRDY))
         continue;
     
     /* Set prescaler to divide by 64.  */
-    PMC->PMC_MCKR = (PMC->PMC_MCKR & AT91C_PMC_CSS)
-        | AT91C_PMC_PRES_CLK_64;
+    PMC->PMC_MCKR = (PMC->PMC_MCKR & PMC_MCKR_CSS_Msk)
+        | PMC_MCKR_PRES_CLK_64;
 
-    while (!(PMC->PMC_SR & AT91C_PMC_MCKRDY))
+    while (!(PMC->PMC_SR & PMC_SR_MCKRDY))
         continue;
 
     /* Disable PLL.  */
-    PMC->PMC_PLLR = 0;
+    PMC->CKGR_PLLAR = CKGR_PLLAR_ONE | CKGR_PLLAR_MULA (0);
 
-    /* Disable main oscillator.  */
-    PMC->PMC_MOR = 0;
-
-    /* Switch voltage regulator to standby (low-power) mode.
-       This reduces its static current requirement from 100 uA to 25 uA.  */
-    VREG->VREG_MR |= AT91C_VREG_PSTDBY;
-#endif
+    ///* Disable main oscillator.  */
+    PMC->CKGR_MOR = CKGR_MOR_KEY (0x37);
 }
 
 

--- a/sam4s/mcu.h
+++ b/sam4s/mcu.h
@@ -28,7 +28,7 @@ mcu_init (void);
 
 
 void
-mcu_power_mode_low (void);
+mcu_select_slowclock (void);
 
 
 void


### PR DESCRIPTION
I renamed "mcu_power_mode_low" to "mcu_select_slowclock" because I thought this was a bit closer to what the function actually does. Thoughts?
