### PR TITLE
Ensure all PIO definitions are actually pio_t instances

### DIFF
--- a/sam4s/pio.h
+++ b/sam4s/pio.h
@@ -30,7 +30,7 @@ extern "C" {
 enum {PORT_A, PORT_B, PORT_C};
 
 /* Enumerate all the PIOs.  */
-#define PIO_DEFINE(PORT, PORTBIT) (((PORT) << 5) + (PORTBIT))
+#define PIO_DEFINE(PORT, PORTBIT) ((pio_t)(((PORT) << 5) + (PORTBIT)))
 
 
 /** Private macro to lookup bitmask.  */


### PR DESCRIPTION
This should fix a compile issue with older versions of the arm gcc, particularly with Ubuntu 16.04 LTS