### PR TITLE
Fix the build for recent versions of newlib (I have 3.0.0.20180226-2)…

### DIFF
--- a/mat91lib.h
+++ b/mat91lib.h
@@ -11,6 +11,7 @@ extern "C" {
 #endif
     
 
+#include <stdio.h>
 #include <stdint.h>
 
 #ifndef __cplusplus


### PR DESCRIPTION
…. Newlib defines __inline differently to mat91lib, which breaks things. So I've let newlib take precedence.