### PR TITLE
Clip calculated SPI clock divisor to the allowable range.

### DIFF
--- a/spi/spi.c
+++ b/spi/spi.c
@@ -358,11 +358,22 @@ spi_clock_speed_t
 spi_clock_speed_kHz_set (spi_t spi, spi_clock_speed_t clock_speed_kHz)
 {
     uint32_t clock_speed;
+    uint32_t divisor;
 
     clock_speed = clock_speed_kHz * 1000;
-    spi_clock_divisor_set (spi, (F_CPU_UL + clock_speed - 1) / clock_speed);
-    clock_speed = F_CPU / spi->clock_divisor;
 
+    /* Calculate the appropriate clock divisor. This must be in the range 1 to
+     * 255 inclusive. Adding the speed and subtracting 1 rounds up when used
+     * with integer division.  */
+    divisor = (F_CPU_UL + clock_speed - 1) / clock_speed;
+    if (divisor > 255)
+        divisor = 255;
+    else if (divisor == 0)
+        divisor = 1;
+
+    /* Set the divisor and return the actual clock speed. */
+    spi_clock_divisor_set (spi, (spi_clock_divisor_t)divisor);
+    clock_speed = F_CPU / spi->clock_divisor;
     return clock_speed / 1000;
 }
 

--- a/spi/spi.h
+++ b/spi/spi.h
@@ -265,7 +265,11 @@ spi_clock_divisor_set (spi_t spi, spi_clock_divisor_t clock_divisor);
 
 
 /** Change the clock speed.  This does not take affect until spi_config
-    or one of the I/O routines is called.  */
+    or one of the I/O routines is called. The desired speed is given in kHz.
+    N.B., the clock divisor calculated by this routine is rounded up, i.e., the
+    clock will be slower than or equal to the given speed. It is also clipped
+    to the allowable range of divisors. The actual clock speed (also in kHz) is
+    returned.  */
 spi_clock_speed_t
 spi_clock_speed_kHz_set (spi_t spi, spi_clock_speed_t clock_speed);
 


### PR DESCRIPTION
The SPI clock divisor is an eight bit field. The old method would simply
take the lower eight bits as the divisor.  This meant that if you asked
for a lower clock speed than possible, it would wrap around to a high
speed.

For example, for a 96MHz peripheral clock a desired speed of 300kHz
would need a divisor of 320. Taking the lower eight bits results in a
divisor of 64, and a SPI clock of 1.5MHz. Clipping the divisor to the
maximum 255 results in the lowest achievable clock speed (~377kHz in
this example).