### PR TITLE
sam4s: irq: add a memory barrier after writing to exception table

### DIFF
--- a/sam4s/irq.h
+++ b/sam4s/irq.h
@@ -77,6 +77,7 @@ static inline void irq_trigger (irq_id_t id)
 static inline void irq_vector_set (irq_id_t id, irq_vector_t isr)
 {
     exception_table[id + 16] = isr;
+    asm volatile ("" ::: "memory");
 }
 
 


### PR DESCRIPTION
Ensures that changes to exception table are fully written to SRAM before
other read/writes are performed.