### PR TITLE
Refactor Makefile

### DIFF
--- a/mat91lib.mk
+++ b/mat91lib.mk
@@ -89,6 +89,13 @@ LDLIBS += -lm -lc
 
 include $(MAT91LIB_DIR)/peripherals.mk
 
+Q=@
+ifdef VERBOSE
+ifneq ($(VERBOSE),0)
+Q=
+endif
+endif
+
 print-drivers:
 	@echo $(DRIVERS)
 
@@ -116,16 +123,18 @@ print-includes:
 # Rule to compile .c file to .o file.
 $(OBJDIR)/%.o: %.c Makefile
 	@mkdir -p "$(@D)"
-	$(CC) $(CFLAGS) -o $@ -c $<
+	$(info CC $<)
+	$(Q)$(CC) $(CFLAGS) -o $@ -c $<
 
 # Rule to create .d file from .c file.
 $(DEPDIR)/%.d: %.c
 	@mkdir -p "$(@D)"
-	$(CC) -MM -MF "$(@)" -MT "$(OBJDIR)/$(<:.c=.o)" $(CFLAGS) $<
+	$(Q)$(CC) -MM -MF "$(@)" -MT "$(OBJDIR)/$(<:.c=.o)" $(CFLAGS) $<
 
 # Link object files to form output file.
 $(TARGET): $(OBJS)
-	$(LD) $(LDFLAGS) -o $@  $^ $(LDLIBS) -Wl,-Map=$(TARGET_MAP),--cref
+	$(info LD $@)
+	$(Q)$(LD) $(LDFLAGS) -o $@  $^ $(LDLIBS) -Wl,-Map=$(TARGET_MAP),--cref
 	$(SIZE) $@
 
 # Remove non-source files.

--- a/mat91lib.mk
+++ b/mat91lib.mk
@@ -153,7 +153,7 @@ endif
 # Program the device.
 .PHONY: program
 program: $(TARGET)
-	$(GDB) -batch -x $(SCRIPTS)/program.gdb $^
+	$(GDB) -batch -x $(SCRIPTS)/program.gdb $<
 
 # Reset the device.
 .PHONY: reset

--- a/mat91lib.mk
+++ b/mat91lib.mk
@@ -108,6 +108,12 @@ print-objs:
 print-cflags:
 	@echo $(CFLAGS)
 
+print-ldflags:
+	@echo $(LDFLAGS)
+
+print-ldlibs:
+	@echo $(LDLIBS)
+
 print-src:
 	@echo $(SRC)
 

--- a/mat91lib.mk
+++ b/mat91lib.mk
@@ -167,5 +167,5 @@ bootflash:
 
 # Attach debugger.
 .PHONY: debug
-debug:
-	$(GDB)  -x $(SCRIPTS)/debug.gdb $(TARGET)
+debug: $(TARGET)
+	$(GDB) -x $(SCRIPTS)/debug.gdb $<

--- a/mat91lib.mk
+++ b/mat91lib.mk
@@ -12,6 +12,10 @@ ifndef MCU
 $(error MCU undefined, this needs to be defined in the Makefile)
 endif
 
+ifndef TARGET
+$(error TARGET undefined)
+endif
+
 ifndef RUN_MODE
 RUN_MODE = ROM
 endif

--- a/sam4s/sam4s.mk
+++ b/sam4s/sam4s.mk
@@ -5,7 +5,7 @@ $(OPT) -mthumb -D__$(MCU)__ -D__SAM4S__ -Wno-unused -Wno-unused-parameter -DARM_
 CXXFLAGS += -mcpu=cortex-m4 -Wall -W -g3 -D$(RUN_MODE) $(sort $(INCLUDES)) \
 $(OPT) -mthumb -D__$(MCU)__ -D__SAM4S__ -Wno-unused -Wno-unused-parameter -DARM_MATH_CM4=true -Wno-missing-field-initializers
 
-LDFLAGS += -mthumb -mcpu=cortex-m4 -lm -lc
+LDFLAGS += -mthumb -mcpu=cortex-m4
 
 INCLUDES += -I$(MAT91LIB_DIR)/$(FAMILY) -I$(MAT91LIB_DIR)/$(FAMILY)/atmel
 

--- a/sam7/sam7.mk
+++ b/sam7/sam7.mk
@@ -2,7 +2,7 @@ CFLAGS += -mcpu=arm7tdmi -Wall -Wstrict-prototypes -W -g3 -D$(RUN_MODE) $(sort $
 
 CXXFLAGS += -mcpu=arm7tdmi -Wall -W -g3 -D$(RUN_MODE) $(sort $(INCLUDES)) $(OPT) -mthumb-interwork -D__$(MCU)__ -D__SAM7__ -Wno-unused -Wno-missing-field-initializers
 
-LDFLAGS += -mthumb-interwork -nostartfiles -lm -lc
+LDFLAGS += -mthumb-interwork -nostartfiles
 
 # This cannot be compiled in thumb mode.
 objs/crt0.o: crt0.c config.h target.h


### PR DESCRIPTION
* Simplify automatic header dependency generating by using gcc `-MMD` and `-MP` flags to handle output paths and target naming; saves having to use sed/printf etc.
* Do not print the full gcc build command by default; makes it a little easier to spot compiler warnings when compiling lots of files.
* Remove C++ support, since C++ has been removed from the library (and mmculib)
* Tidy Makefiles up a little, including using the split LDFLAGS/LDLIBS that make uses by default: see *Linking a single object file* heading in https://www.gnu.org/software/make/manual/html_node/Catalogue-of-Rules.html#Catalogue-of-Rules 