### PR TITLE
Include stdbool instead of manually defining bool, true, and false

### DIFF
--- a/mat91lib.h
+++ b/mat91lib.h
@@ -10,15 +10,9 @@
 extern "C" {
 #endif
     
-
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdint.h>
-
-#ifndef __cplusplus
-enum {false = 0, true = 1};
-typedef uint8_t bool;
-#endif
-
 
 #ifndef BIT
 #define BIT(X) (1U << (X))


### PR DESCRIPTION
Currently very sensitive to ordering of `#include`s, especially when including 3rd party libs that include `stdbool.h`