### PR TITLE
SAM4SA16B support, use OpenOCD pipe, do not add systick/sysclock by default

### DIFF
--- a/mat91lib.mk
+++ b/mat91lib.mk
@@ -158,7 +158,11 @@ ifdef CLEAN_EXTRA_PATHS
 	-$(DEL) -r $(CLEAN_EXTRA_PATHS)
 endif
 
-GDB_ARGS += -ex 'target extended-remote | openocd -c "gdb_port pipe" -f "$(SCRIPTS)/$(OPENOCD_SCRIPT)"'
+OPENOCD_ARGS = \
+	-c "gdb_port pipe" \
+	-f "$(SCRIPTS)/$(OPENOCD_SCRIPT)" \
+	$(OPENOCD_EXTRA_ARGS)
+GDB_ARGS += -ex 'target extended-remote | openocd $(OPENOCD_ARGS)'
 
 # Program the device.
 .PHONY: program

--- a/mat91lib.mk
+++ b/mat91lib.mk
@@ -48,9 +48,11 @@ TARGET_MAP = $(addsuffix .map, $(basename $(TARGET)))
 
 ifneq (, $(findstring SAM7, $(MCU)))
 FAMILY = sam7
+OPENOCD_SCRIPT ?= sam7_ft2232.cfg
 else
 ifneq (, $(findstring SAM4S, $(MCU)))
 FAMILY = sam4s
+OPENOCD_SCRIPT ?= sam4s_stlink.cfg
 else
 $(error unknown family)
 endif
@@ -156,22 +158,24 @@ ifdef CLEAN_EXTRA_PATHS
 	-$(DEL) -r $(CLEAN_EXTRA_PATHS)
 endif
 
+GDB_ARGS += -ex 'target extended-remote | openocd -c "gdb_port pipe" -f "$(SCRIPTS)/$(OPENOCD_SCRIPT)"'
+
 # Program the device.
 .PHONY: program
 program: $(TARGET)
-	$(GDB) -batch -x $(SCRIPTS)/program.gdb $<
+	$(GDB) -batch $(GDB_ARGS) -x $(SCRIPTS)/program.gdb $<
 
 # Reset the device.
 .PHONY: reset
 reset:
-	$(GDB) -batch -x $(SCRIPTS)/reset.gdb $(TARGET)
+	$(GDB) -batch $(GDB_ARGS) -x $(SCRIPTS)/reset.gdb $(TARGET)
 
 # Enable booting from flash.
 .PHONY: bootflash
 bootflash:
-	$(GDB) -batch -x $(SCRIPTS)/bootflash.gdb
+	$(GDB) -batch $(GDB_ARGS) -x $(SCRIPTS)/bootflash.gdb
 
 # Attach debugger.
 .PHONY: debug
 debug: $(TARGET)
-	$(GDB) -x $(SCRIPTS)/debug.gdb $<
+	$(GDB) $(GDB_ARGS) -x $(SCRIPTS)/debug.gdb $<

--- a/peripherals.mk
+++ b/peripherals.mk
@@ -1,5 +1,3 @@
-PERIPHERALS += pit sysclock systick
-
 include $(foreach peripheral, $(PERIPHERALS), $(MAT91LIB_DIR)/$(peripheral)/$(peripheral).mk)
 
 # Perform second pass for the peripherals that depend on other peripherals

--- a/sam4s/SAM4SA16B-ROM.ld
+++ b/sam4s/SAM4SA16B-ROM.ld
@@ -1,0 +1,8 @@
+MEMORY
+{
+        /* The 16 kB is ROM for bootloader.  */
+        FLASH (rx) : ORIGIN = 0x00400000, LENGTH = 1M
+        SRAM (rwx) : ORIGIN = 0x20000000, LENGTH = 160K
+}
+
+INCLUDE SAM4SX-ROM.ld

--- a/sam4s/scripts/bootflash.gdb
+++ b/sam4s/scripts/bootflash.gdb
@@ -1,9 +1,6 @@
 # Set the Architecture to arm
 set architecture arm
 
-# OpenOCD port for GDB communications
-target remote tcp:localhost:3333
-
 # Set bit to boot from flash rather than running bootloader
 # You should see it change from the first command to the third here
 monitor at91sam4 gpnvm

--- a/sam4s/scripts/debug.gdb
+++ b/sam4s/scripts/debug.gdb
@@ -1,6 +1,3 @@
-# OpenOCD port for GDB communications
-target remote tcp:localhost:3333
-
 define PMC
     p/x *((Pmc    *)0x400E0400U)
 end

--- a/sam4s/scripts/program.gdb
+++ b/sam4s/scripts/program.gdb
@@ -1,6 +1,3 @@
-# OpenOCD port for GDB communications
-target remote tcp:localhost:3333
-
 # Fire the reset-init event which fires the event handler defined in "at91sam7x256.cfg"; this programs the clock and sets things up
 monitor reset init
 
@@ -12,4 +9,3 @@ monitor sleep 500
 load
 
 monitor reset
-

--- a/sam4s/scripts/reset.gdb
+++ b/sam4s/scripts/reset.gdb
@@ -1,6 +1,2 @@
-# OpenOCD port for GDB communications
-target remote tcp:localhost:3333
-
 # Reset the target
 monitor reset run
-

--- a/sam4s/scripts/sam4s_stlink.cfg
+++ b/sam4s/scripts/sam4s_stlink.cfg
@@ -3,9 +3,6 @@ set CPUTAPID 0x2ba01477
 source [find "interface/stlink-v2.cfg"]
 source [find "target/at91sam4sXX.cfg"]
 
-telnet_port 4444
-gdb_port 3333
-
 $_TARGETNAME configure -event gdb-attach {
    echo "Halting target due to gdb attach"
    halt

--- a/sam7/scripts/debug.gdb
+++ b/sam7/scripts/debug.gdb
@@ -1,6 +1,3 @@
-# OpenOCD port for GDB communications
-target remote tcp:localhost:3333
-
 # Enable fast memory access (may be less stable, comment out if problems arise)
 monitor arm7_9 fast_memory_access enable
 

--- a/sam7/scripts/program.gdb
+++ b/sam7/scripts/program.gdb
@@ -1,6 +1,3 @@
-# OpenOCD port for GDB communications
-target remote tcp:localhost:3333
-
 # Enabling DCC downloads boosted download speed from 26kB/s to 154kB/s
 monitor arm7_9 dcc_downloads enable
 

--- a/sam7/scripts/reset.gdb
+++ b/sam7/scripts/reset.gdb
@@ -1,6 +1,3 @@
-# OpenOCD port for GDB communications
-target remote tcp:localhost:3333
-
 # Reset the target
 monitor reset
 monitor soft_reset_halt

--- a/sysclock/sysclock.mk
+++ b/sysclock/sysclock.mk
@@ -1,1 +1,3 @@
+PERIPHERALS += systick
+
 include $(MAT91LIB_DIR)/$(FAMILY)/sysclock/sysclock.mk


### PR DESCRIPTION
A few minor changes plus an addition that I have found quite useful: `make program`, `make debug` etc. can be run without requiring am OpenOCD server run from a separate terminal. Works by opening a pipe between GDB and OpenOCD.