### PR TITLE
Remove #define of __inline

### DIFF
--- a/mat91lib.h
+++ b/mat91lib.h
@@ -42,10 +42,6 @@ extern "C" {
 #define __packed__
 #endif
 
-#ifndef __inline
-#define __inline static inline
-#endif
-
 #if defined (__SAM7__)
 #include "sam7.h"
 #elif defined (__SAM4S__)


### PR DESCRIPTION
This fixes compile errors where 'static __inline' is used in any standard library headers that have been included after mat91lib.h.

(Use of `__inline` could probably be change to `inline` as long as >=C99 is used...)